### PR TITLE
Removed usage of SSL in favor of the current TLS, added integrity, cleared up connection wording.

### DIFF
--- a/how-https-works.md
+++ b/how-https-works.md
@@ -5,14 +5,14 @@ permalink: /how-https-works/
 menu_weight: 20
 ---
 
-HTTPS provides two security features: **server identification** and **encryption**.
+HTTPS provides these security features: **server identification**, **integrity** and **encryption**.
 
-**Server identification** ensures that the user makes an authentic connection to the real website, and not a man-in-the-middle impersonating the website. Server identification is verified with an **SSL certificate** and **public key encryption**.
+**Server identification** ensures that the user makes an authentic connection to the real website, and not a man-in-the-middle impersonating the website. Server identification is verified with an **TLS certificate** and **public key encryption**.
 
-A **certificate authority** (CA) validates that an organization has ownership of a domain, and then issues an SSL certificate for the domain.
+A **certificate authority** (CA) validates that an organization has ownership of a domain, and then issues an TLS certificate for the domain.
 
-When initializing a connection over HTTPS, the server sends the client its SSL certificate. An SSL certificate contains a **digital signature** and the **web server's public key**.
+When initializing a connection over HTTPS, the server sends the client its TLS certificate. An TLS certificate contains a **digital signature** and the **web server's public key**.
 
-The digital signature proves that a specific certificate authority created a certificate. A browser or operating system implicitly trusts certain certificate authorities, and holds a copy of the root certificate. When receiving an SSL certificate from a website, the client can confirm the certificate's authenticity by comparing the digital signature with the signer's public key.
+The digital signature proves that a specific certificate authority created a certificate. A browser or operating system implicitly trusts certain certificate authorities, and holds a copy of the root certificate. When receiving an TLS certificate from a website, the client can confirm the certificate's authenticity by comparing the digital signature with the signer's public key.
 
 The certificate also includes the web server's public key. If the digital signature is verified, the public key can be trusted as well. The public key is used in negotiating the encryption scheme between the client and the web server. Although attackers might be able to get an encrypted message, they can't decode it.

--- a/how-https-works.md
+++ b/how-https-works.md
@@ -5,14 +5,16 @@ permalink: /how-https-works/
 menu_weight: 20
 ---
 
-HTTPS provides these security features: **server identification**, **integrity** and **encryption**.
+Given a correct setup with current software in use by all participants HTTPS provides these security features: **authenticity** via server identification, **data integrity** via checksums and **privacy** via encryption.
 
-**Server identification** ensures that the user makes an authentic connection to the real website, and not a man-in-the-middle impersonating the website. Server identification is verified with an **TLS certificate** and **public key encryption**.
+**Server identification** ensures that the user only connects to the website if it can prove to be the one it claims. A man-in-the-middle impersonating the website will be detected. Server identification is verified with a **TLS certificate** and **public key encryption**.
 
-A **certificate authority** (CA) validates that an organization has ownership of a domain, and then issues an TLS certificate for the domain.
+A **certificate authority** (CA) issues TLS certificates for hostnames, usually in exchange for money. 
 
-When initializing a connection over HTTPS, the server sends the client its TLS certificate. An TLS certificate contains a **digital signature** and the **web server's public key**.
+When a client initiates a connection to an HTTPS server, the server responds with its TLS certificate. A TLS certificate contains a **digital signature** of the issuing CA and the **web server's public key**.
 
-The digital signature proves that a specific certificate authority created a certificate. A browser or operating system implicitly trusts certain certificate authorities, and holds a copy of the root certificate. When receiving an TLS certificate from a website, the client can confirm the certificate's authenticity by comparing the digital signature with the signer's public key.
+The digital signature proves that a specific certificate authority created a certificate. A browser or operating system implicitly trusts certain certificate authorities, and holds a copy of their respecting root certificates. When receiving a TLS certificate from a website, the client can verify the certificate's authenticity by checking the digital signature with the signer's public key.
 
-The certificate also includes the web server's public key. If the digital signature is verified, the public key can be trusted as well. The public key is used in negotiating the encryption scheme between the client and the web server. Although attackers might be able to get an encrypted message, they can't decode it.
+The certificate also includes the web server's public key. When the digital signature is correctly verified, the public key can be trusted as well. The public key is used in negotiating the encryption scheme between the client and the web server. Although attackers might be able to get an encrypted message, they can't decode it.
+
+**Data integrity** maintains consistency of the data sent and received. This makes manipulation of the encrypted data in transit detectable.

--- a/setup-https.md
+++ b/setup-https.md
@@ -11,9 +11,9 @@ To configure a website to serve HTTPS, you will need to modify the web server's 
 
 Sever Name Indication (SNI) allows a client to connect to different sites hosted on a single IP address. Most web hosts only work with SNI by default, so supporting older clients that don't support SNI (e.g. Internet Explorer on Windows XP) is an extra configuration step. [Learn more about SNI](https://https.cio.gov/sni/), and decide whether or not to support these clients.
 
-## Get an TLS certificate and private key
+## Get a TLS certificate and private key
 
-A web server needs a private key and an TLS certificate (which includes a public key) to serve HTTPS.
+A web server needs a private key and a TLS certificate (which includes a public key) to serve HTTPS.
 
 An TLS certificate should be acquired from a trusted certificate authority.
 

--- a/setup-https.md
+++ b/setup-https.md
@@ -15,7 +15,7 @@ Sever Name Indication (SNI) allows a client to connect to different sites hosted
 
 A web server needs a private key and a TLS certificate (which includes a public key) to serve HTTPS.
 
-An TLS certificate should be acquired from a trusted certificate authority.
+A TLS certificate should be acquired from a trusted certificate authority.
 
 [SSLMate](https://sslmate.com/) is a nice command-line tool to purchase certificates.
 

--- a/setup-https.md
+++ b/setup-https.md
@@ -11,11 +11,11 @@ To configure a website to serve HTTPS, you will need to modify the web server's 
 
 Sever Name Indication (SNI) allows a client to connect to different sites hosted on a single IP address. Most web hosts only work with SNI by default, so supporting older clients that don't support SNI (e.g. Internet Explorer on Windows XP) is an extra configuration step. [Learn more about SNI](https://https.cio.gov/sni/), and decide whether or not to support these clients.
 
-## Get an SSL certificate and private key
+## Get an TLS certificate and private key
 
-A web server needs a private key and an SSL certificate (which includes a public key) to serve HTTPS.
+A web server needs a private key and an TLS certificate (which includes a public key) to serve HTTPS.
 
-An SSL certificate should be acquired from a trusted certificate authority.
+An TLS certificate should be acquired from a trusted certificate authority.
 
 [SSLMate](https://sslmate.com/) is a nice command-line tool to purchase certificates.
 


### PR DESCRIPTION
Replaced occurrences of “SSL” with TLS since **all** versions of SSL are cryptographically and technically broken in practice. SSL should never be used at all anymore, hence the usage of the correct term “TLS” is highly encouraged.

Added **integrity** and a small explanation of it to the benefits of using HTTPS.

Made the server identification explanation more specific to reduce the risk of confusion which parts of the connection are handled by TLS and which are actually done prior by DNS.

Removed part with the domain ownership verification by CAs since they actually don't do that. Ownership of a domain is not a requirement for the issuance of a certificate for a hostname under that domain.

Made clear that a connection is initiated by the client, not a server.
